### PR TITLE
update DC config for medicaid threshold child category

### DIFF
--- a/config/state_config.json
+++ b/config/state_config.json
@@ -194,7 +194,7 @@
           {
             "minimum": 0,
             "maximum": 18,
-            "threshold": 319
+            "threshold": 324
           },{
             "minimum": 19,
             "maximum": 20,


### PR DESCRIPTION
[IVL-181510571](https://www.pivotaltracker.com/n/projects/2481183/stories/181510571)

- Client feedback for one of the failed DC EE core 29 scenarios (QA-CORE-4-IA_IA-01a) indicates "the income threshold for MAGI Medicaid for children 18 years and younger in the District is 324% of FPL. System may not be configured correctly."