### PR TITLE
enable cross-compilation in Dockerfile and update build-and-deploy workflow for multi-architecture support

### DIFF
--- a/.docker/production/Dockerfile.gha
+++ b/.docker/production/Dockerfile.gha
@@ -1,7 +1,13 @@
 ############################################
 ### Base image ###
 ############################################
-FROM debian:bullseye-slim AS base
+# FROM debian:bullseye-slim AS base
+
+# cross-compilation: expose buildkit platform args for FROM
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+FROM --platform=$BUILDPLATFORM debian:bullseye-slim AS base
+
 LABEL author="IdeaCrew"
 
 # These first run commands will add the stretch repo to the sources list

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - "trunk"
+      - 'buildx-multiarch'
   pull_request:
     branches:
       - "trunk"
+      - 'buildx-multiarch'
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -61,6 +63,7 @@ jobs:
           echo -e "current branch: $(git rev-parse --abbrev-ref HEAD)\n\n$(git show --quiet HEAD)" > public/release.txt
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
         with:
           install: true
@@ -93,6 +96,8 @@ jobs:
       - name: Build Image
         uses: docker/build-push-action@v3
         with:
+          # cross-compilation: build images for both amd64 and arm64 on non 'pull_request'
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: .docker/production/Dockerfile.gha


### PR DESCRIPTION
Ticket: [CU-868hje4kv](https://app.clickup.com/t/868hje4kv)
___________________________________________________________________________________________________

This pull request introduces enhancements to the Docker build process, enabling cross-platform image builds for both `amd64` and `arm64` architectures. It also updates the GitHub Actions workflow to support multi-architecture builds and adds a new branch for testing these changes.

**Docker build cross-platform support:**

* Updated `.docker/production/Dockerfile.gha` to expose BuildKit platform arguments (`BUILDPLATFORM`, `TARGETPLATFORM`) and use the `--platform` flag in the `FROM` statement, allowing for cross-compilation and multi-architecture builds.

**GitHub Actions workflow improvements:**

* Modified `.github/workflows/build-image.yml` to build Docker images for both `amd64` and `arm64` architectures except on pull requests, where only `amd64` is built.
* Added a new branch (`buildx-multiarch`) to the workflow triggers for both push and pull request events, enabling testing and deployment of multi-architecture builds.
* Added an `id` to the Buildx setup step to ensure proper referencing of the builder in subsequent steps.