### PR TITLE
enhance Dockerfile and CI workflow for multi-architecture builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -63,6 +63,7 @@ jobs:
           echo -e "current branch: $(git rev-parse --abbrev-ref HEAD)\n\n$(git show --quiet HEAD)" > public/release.txt
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
         with:
           install: true
@@ -95,6 +96,8 @@ jobs:
       - name: Build Image
         uses: docker/build-push-action@v3
         with:
+          # cross-compilation: build images for both amd64 and arm64 on non 'pull_request'
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: .docker/production/Dockerfile.gha


### PR DESCRIPTION
Current behavior: We lost the ability to build docker images with arm64 platform when we upgraded buildx version.

New behavior: Enabled buildx multi-arch (linux/amd64,linux/arm64) to build images with arm64 which is needed for our local environment with docker desktop. BuildKit platform args were already added as part of an older PR.


**_Notes from Local Testing:_**
* I was able to successfully deploy the new image built with this branch in local CME K8s with docker environment.
* I was also able to get Financial Assistance determinations